### PR TITLE
Allow per app configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ An Ansible Role that sets up automated remote backups on the target machine. Use
 
 ### Optional Arguments
 - `borg_encryption_passphrase`: Password to use for repokey or keyfile. Empty if repo is unencrypted.
-- `borgmatic_config_name`: Name to use for the borgmatic config file. Defaults to `config.yml`
 - `borgmatic_large_repo`: Does repo-checking on a weekly basis instead of daily. Good for repos with 100GB+ size.
 - `borgmatic_failure_command`: Run this command when an error occurs. E.g. `curl -s -F "token=xxx" -F "user=xxx" -F "message=Error during backup" https://api.pushover.net/1/messages.json`
 - `borg_exclude_patterns`: Paths or patterns to exclude from backup. See [official documentation](https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-patterns) for more.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 borg_encryption_passphrase: ''
 borg_exclude_patterns: []
-borgmatic_config_name: config.yaml
 borgmatic_large_repo: false
 borgmatic_failure_command: echo "`date` - Error while creating a backup."
 borg_one_file_system: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,13 @@
 - include: "{{ ansible_pkg_mgr }}.yml"
 
 - name: Install required System Packages
-  package: 
+  package:
     pkg: "{{ item }}"
     state: installed
   with_items: "{{ borg_packages }}"
 
 - name: Update setuptools if needed
-  pip: 
+  pip:
     name: setuptools
     state: latest
     executable: "{{ pip_bin }}"
@@ -31,9 +31,9 @@
 - debug:
     var: root_user['ssh_public_key']
 
-- name: Ensures /etc/borgmatic exists
+- name: Ensures /etc/borgmatic.d exists
   file:
-    path: /etc/borgmatic
+    path: /etc/borgmatic.d
     state: directory
     mode: 0700
     owner: root
@@ -41,37 +41,41 @@
 - name: Add Borgmatic Configuration
   template:
     src: config.yaml.j2
-    dest: "/etc/borgmatic/{{ borgmatic_config_name }}"
+    dest: "/etc/borgmatic.d/{{ item | regex_replace('\\/$', '') | basename }}.yaml"
     mode: 0600
+  with_items: "{{ borg_source_directories }}"
+
+- debug: msg="/etc/borgmatic.d/{{ item | regex_replace('\\/$', '') | basename }}.yaml"
+  with_items: "{{ borg_source_directories }}"
 
 - name: Add cron-job for borgmatic (large repo, create and check separate)
   block:
-    - cron: 
+    - cron:
         name: "borgmatic"
         hour: "{{ 6 |random }}"
         minute: "{{ 59 |random }}"
         user: "root"
         cron_file: borgmatic
-        job: "/usr/local/bin/borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} --create --prune"
-    - cron: 
+        job: "/usr/local/bin/borgmatic --create --prune"
+    - cron:
         name: "borgmatic-check"
         day: "{{ 28 | random }}"
         hour: "{{ range(7, 24) | random }}"
         minute: "{{ 59 | random }}"
         user: "root"
         cron_file: borgmatic
-        job: "/usr/local/bin/borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} --check"
+        job: "/usr/local/bin/borgmatic --check"
   when: borgmatic_large_repo
 
 - name: Add cron-job for borgmatic (normal-sized repo)
   block:
-    - cron: 
+    - cron:
         name: "borgmatic"
         hour: "{{ 6 | random }}"
         minute: "{{ 59 | random }}"
         user: "root"
         cron_file: borgmatic
-        job: "/usr/local/bin/borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }}"
+        job: "/usr/local/bin/borgmatic"
     - cron:
         name: "borgmatic-check"
         state: absent

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -1,10 +1,9 @@
 # Full config: https://gist.github.com/coaxial/46e36d89d7b81887f7275d587fe04c44
+{% set archive_name = item | regex_replace("\\/$", "") | basename %}
 location:
     source_directories:
-{% for dir in borg_source_directories %}
-        - {{ dir }}
-{% endfor %}
-    
+        - {{ item }}
+
     # Stay in same file system (do not cross mount points).
     one_file_system: {{ borg_one_file_system }}
     repositories:
@@ -73,7 +72,7 @@ storage:
     # also specify a prefix in the retention section to avoid accidental pruning of
     # archives with a different archive name format. And you should also specify a
     # prefix in the consistency section as well.
-    archive_name_format: '{hostname}-{now}'
+    archive_name_format: '{{ item | regex_replace("\\/$", "") | basename }}-{now}'
 
 # Retention policy for how many backups to keep in each category. See
 # https://borgbackup.readthedocs.org/en/stable/usage.html#borg-prune for details.
@@ -94,7 +93,7 @@ retention:
     # When pruning, only consider archive names starting with this prefix.
     # Borg placeholders can be used. See the output of "borg help placeholders" for
     # details. Default is "{hostname}-".
-    prefix: '{hostname}-'
+    prefix: '{{ item | regex_replace("\\/$", "") | basename }}-'
 
 # Consistency checks to run after backups. See
 # https://borgbackup.readthedocs.org/en/stable/usage.html#borg-check and
@@ -115,7 +114,7 @@ consistency:
     # When performing the "archives" check, only consider archive names starting with
     # this prefix. Borg placeholders can be used. See the output of
     # "borg help placeholders" for details. Default is "{hostname}-".
-    prefix: '{hostname}-'
+    prefix: '{{ item | regex_replace("\\/$", "") | basename }}-'
 
 # Shell commands or scripts to execute before and after a backup or if an error has occurred.
 # IMPORTANT: All provided commands and scripts are executed with user permissions of borgmatic.

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -1,5 +1,5 @@
 # Full config: https://gist.github.com/coaxial/46e36d89d7b81887f7275d587fe04c44
-{% set archive_name = item | regex_replace("\\/$", "") | basename %}
+{% set archive_prefix = item | regex_replace("\\/$", "") | basename %}
 location:
     source_directories:
         - {{ item }}
@@ -72,7 +72,7 @@ storage:
     # also specify a prefix in the retention section to avoid accidental pruning of
     # archives with a different archive name format. And you should also specify a
     # prefix in the consistency section as well.
-    archive_name_format: '{{ item | regex_replace("\\/$", "") | basename }}-{now}'
+    archive_name_format: '{{ archive_prefix }}-{now}'
 
 # Retention policy for how many backups to keep in each category. See
 # https://borgbackup.readthedocs.org/en/stable/usage.html#borg-prune for details.
@@ -93,7 +93,7 @@ retention:
     # When pruning, only consider archive names starting with this prefix.
     # Borg placeholders can be used. See the output of "borg help placeholders" for
     # details. Default is "{hostname}-".
-    prefix: '{{ item | regex_replace("\\/$", "") | basename }}-'
+    prefix: '{{ archive_prefix }}-'
 
 # Consistency checks to run after backups. See
 # https://borgbackup.readthedocs.org/en/stable/usage.html#borg-check and
@@ -114,7 +114,7 @@ consistency:
     # When performing the "archives" check, only consider archive names starting with
     # this prefix. Borg placeholders can be used. See the output of
     # "borg help placeholders" for details. Default is "{hostname}-".
-    prefix: '{{ item | regex_replace("\\/$", "") | basename }}-'
+    prefix: '{{ archive_prefix }}-'
 
 # Shell commands or scripts to execute before and after a backup or if an error has occurred.
 # IMPORTANT: All provided commands and scripts are executed with user permissions of borgmatic.


### PR DESCRIPTION
This PR allows for multiple per application borgmatic configurations as per this article: https://torsion.org/borgmatic/docs/how-to/make-per-application-backups/
This PR is backwards compatible. However, to achieve this the config name is inferred from the source directory. A cleaner way to achieve this might be to modify `borg_source_directories` like so:

    borg_source_directories:
        - name: example.com
          dir: /var/www/example.com

However, I didnt go that far with this PR.

Let me know what you think!