### PR TITLE
Added before and after borgmatic hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ An Ansible Role that sets up automated remote backups on the target machine. Use
 - `borgmatic_config_name`: Name to use for the borgmatic config file. Defaults to `config.yml`
 - `borgmatic_large_repo`: Does repo-checking on a weekly basis instead of daily. Good for repos with 100GB+ size.
 - `borgmatic_failure_command`: Run this command when an error occurs. E.g. `curl -s -F "token=xxx" -F "user=xxx" -F "message=Error during backup" https://api.pushover.net/1/messages.json`
+- `borgmatic_before_backup_command`: Run this command before the backup. E.g. `dump-a-database /to/file.sql`
+- `borgmatic_after_backup_command`: Run this command after the backup. E.g. `rm /to/file.sql`
+- `borgmatic_failure_command`: Run this command when an error occurs. E.g. `curl -s -F "token=xxx" -F "user=xxx" -F "message=Error during backup" https://api.pushover.net/1/messages.json`
 - `borg_exclude_patterns`: Paths or patterns to exclude from backup. See [official documentation](https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-patterns) for more.
 - `borg_one_file_system`: Don't cross file-system boundaries. Defaults to `true`
 - `borg_exclude_from`: Read exclude patterns from one or more separate named files, one pattern per line.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,8 @@ borg_encryption_passphrase: ''
 borg_exclude_patterns: []
 borgmatic_config_name: config.yaml
 borgmatic_large_repo: false
-borgmatic_failure_command: echo "`date` - Error while creating a backup."
+borgmatic_failure_command:
+  - echo "`date` - Error while creating a backup."
 borgmatic_before_backup_command: []
 borgmatic_after_backup_command: []
 borg_one_file_system: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@ borg_exclude_patterns: []
 borgmatic_config_name: config.yaml
 borgmatic_large_repo: false
 borgmatic_failure_command: echo "`date` - Error while creating a backup."
+borgmatic_before_backup_command: []
+borgmatic_after_backup_command: []
 borg_one_file_system: true
 borg_exclude_from: []
 borg_encryption_passcommand: false

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -125,10 +125,16 @@ hooks:
     # List of one or more shell commands or scripts to execute before creating a backup.
     before_backup:
         - echo "`date` - Starting backup."
+{% for cmd in borgmatic_before_backup_command %}
+        - {{ cmd }}
+{% endfor %}
 
     # List of one or more shell commands or scripts to execute after creating a backup.
     after_backup:
         - echo "`date` - Finished backup."
+{% for cmd in borgmatic_after_backup_command %}
+        - {{ cmd }}
+{% endfor %}
 
     # List of one or more shell commands or scripts to execute in case an exception has occurred.
     on_error:

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -161,4 +161,6 @@ hooks:
 
     # List of one or more shell commands or scripts to execute in case an exception has occurred.
     on_error:
-        - {{ borgmatic_failure_command }}
+{% for cmd in borgmatic_failure_command %}
+        - {{ cmd }}
+{% endfor %}


### PR DESCRIPTION
This allows you to use this role to run a number of scripts/commands before and after backup using the hooks provided by borgmatic. See https://torsion.org/borgmatic/docs/how-to/add-preparation-and-cleanup-steps-to-backups/#preparation-and-cleanup-hooks

You can specify multiple commands like so:

    borgmatic_before_backup_command:
        - dump-a-database /to/file.sql
        - echo "`date` - Backup hook doing work!"