### PR TITLE
Making some compatibility changes and one small improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ An Ansible Role that sets up automated remote backups on the target machine. Use
 - `borg_ssh_command`: Command to use instead of just "ssh". This can be used to specify ssh options.
 - `borg_encryption_passcommand`: The standard output of this command is used to unlock the encryption key.
 - `borg_retention_policy`: Retention policy for how many backups to keep in each category (daily, weekly, monthly, etc).
+- `borgmatic_cron_hour`: Configure the hour when the backup shall run. Default is randomized between 0-6 local time.
+- `borgmatic_cron_minute`: Configure the minute when the backup shall run. Default is randomized between 0-59 local time.
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,6 @@ borg_retention_policy:
   keep_daily: 7
   keep_weekly: 4
   keep_monthly: 6
+
+borgmatic_cron_hour: "{{ 6 | random }}"
+borgmatic_cron_minute: "{{ 59 | random }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,17 +16,9 @@
 
 - name: Install required Python Packages
   pip:
-    name: "{{ item }}"
+    name: "{{ borg_python_packages }}"
+    state: latest
     executable: "{{ pip_bin }}"
-  with_items: "{{ borg_python_packages }}"
-
-- name: Ensure root has SSH key.
-  user:
-    name: "root"
-    generate_ssh_key: yes
-    ssh_key_file: .ssh/id_ed25519
-    ssh_key_type: ed25519
-  register: root_user
 
 - debug:
     var: root_user['ssh_public_key']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Install required System Packages
   package: 
     pkg: "{{ item }}"
-    state: installed
+    state: present
   with_items: "{{ borg_packages }}"
 
 - name: Update setuptools if needed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- include_vars: '{{ ansible_pkg_mgr }}.yml'
-- include: "{{ ansible_pkg_mgr }}.yml"
+- include_vars: "{{ ansible_pkg_mgr }}.yml"
+- include_tasks: "{{ ansible_pkg_mgr }}.yml"
 
 - name: Install required System Packages
   package: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,9 +20,6 @@
     state: latest
     executable: "{{ pip_bin }}"
 
-- debug:
-    var: root_user['ssh_public_key']
-
 - name: Ensures /etc/borgmatic exists
   file:
     path: /etc/borgmatic

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,8 +37,8 @@
   block:
     - cron: 
         name: "borgmatic"
-        hour: "{{ 6 |random }}"
-        minute: "{{ 59 |random }}"
+        hour: "{{ borgmatic_cron_hour }}"
+        minute: "{{ borgmatic_cron_minute }}"
         user: "root"
         cron_file: borgmatic
         job: "/usr/local/bin/borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} --create --prune"
@@ -56,8 +56,8 @@
   block:
     - cron: 
         name: "borgmatic"
-        hour: "{{ 6 | random }}"
-        minute: "{{ 59 | random }}"
+        hour: "{{ borgmatic_cron_hour }}"
+        minute: "{{ borgmatic_cron_minute }}"
         user: "root"
         cron_file: borgmatic
         job: "/usr/local/bin/borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }}"


### PR DESCRIPTION
Hi,
Using this role led to some deprecation warnings so I fixed them.
I also removed the "make sure root has key" - well I don't see any point why this is needed. To test if a ssh-key is needed by the borg client you shall use a different test. (maybe something like a `borgmatic list`check or something that proves working config.)

Also I made the cronjob a bit more configurable as I needed that :)

Would be nice we can achieve the thing to create multiple jobs. Currently I don't have a good idea to make it easy (without array fields) for end-user-admins using this role :)