### PR TITLE
Allow to specify borg remote-path argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ An Ansible Role that sets up automated remote backups on the target machine. Use
 - `borg_one_file_system`: Don't cross file-system boundaries. Defaults to `true`
 - `borg_exclude_from`: Read exclude patterns from one or more separate named files, one pattern per line.
 - `borg_ssh_command`: Command to use instead of just "ssh". This can be used to specify ssh options.
+- `borg_remote_path`: Path to the borg executable on the remote. It will default to `borg`.
 - `borg_encryption_passcommand`: The standard output of this command is used to unlock the encryption key.
 - `borg_retention_policy`: Retention policy for how many backups to keep in each category (daily, weekly, monthly, etc).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ borg_one_file_system: true
 borg_exclude_from: []
 borg_encryption_passcommand: false
 borg_ssh_command: false
+borg_remote_path: false
 borg_retention_policy:
   keep_hourly: 3
   keep_daily: 7

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -30,6 +30,12 @@ location:
     # Exclude directories that contain a file with the given filename.
     exclude_if_present: .nobackup
 
+    # Alternate Borg remote executable. Defaults to "borg".
+    # remote_path: borg1
+{% if borg_remote_path %}
+    remote_path: {{ borg_remote_path }}
+{% endif %}
+
 # Repository storage options. See
 # https://borgbackup.readthedocs.io/en/stable/usage.html#borg-create and
 # https://borgbackup.readthedocs.io/en/stable/usage/general.html#environment-variables for


### PR DESCRIPTION
I'm using a server where both Borg 0.x and 1.x are installed. The `borg`
command use the version 0.x but I need the version 1.x. This option
allows me to override the borg remote path with `borg1`.