### PR TITLE
Add a ssh_key_file optional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ An Ansible Role that sets up automated remote backups on the target machine. Use
 - `borg_remote_path`: Path to the borg executable on the remote. It will default to `borg`.
 - `borg_encryption_passcommand`: The standard output of this command is used to unlock the encryption key.
 - `borg_retention_policy`: Retention policy for how many backups to keep in each category (daily, weekly, monthly, etc).
+- `ssh_key_file`: Path to a private ssh key file (default is `.ssh/id_ed25519`). It generates a ed25519 key if the file doesn't exist yet.
 
 ### Optional Arguments for [BorgBase.com](https://www.borgbase.com) repository auto creation
 - `create_repo`: Whether to let the role create the repository for the server. Default: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ borg_retention_policy:
   keep_weekly: 4
   keep_monthly: 6
 create_repo: False
+ssh_key_file: .ssh/id_ed25519
 bb_new_sshkey: True
 bb_append: True
 bb_quota: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
   user:
     name: "root"
     generate_ssh_key: yes
-    ssh_key_file: .ssh/id_ed25519
+    ssh_key_file: "{{ ssh_key_file }}"
     ssh_key_type: ed25519
   register: root_user
 


### PR DESCRIPTION
I already had an existing SSH key, with a different name. I wanted to be
able to use this one instead of creating another key, potentially used
for another server.