### PR TITLE
add missing python wheel package needed in CentOS 7

### DIFF
--- a/vars/yum.yml
+++ b/vars/yum.yml
@@ -6,6 +6,7 @@ borg_packages:
   - gcc-c++
   - openssl-devel
   - python36-pip
+  - python36-wheel
   - python36-devel
 
 python_bin: python3


### PR DESCRIPTION
pip install will error out as wheel package is missing unless installed explicitly