### PR TITLE
Prune and check for large repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ An Ansible Role that sets up automated remote backups on the target machine. Use
 - `borg_exclude_patterns`: Paths or patterns to exclude from backup. See [official documentation](https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-patterns) for more.
 - `borg_one_file_system`: Don't cross file-system boundaries. Defaults to `true`
 - `borg_exclude_from`: Read exclude patterns from one or more separate named files, one pattern per line.
+- `borg_lock_wait_time`: Config maximum seconds to wait for acquiring a repository/cache lock. Defaults to 5 seconds.
 - `borg_ssh_command`: Command to use instead of just "ssh". This can be used to specify ssh options.
 - `borg_remote_path`: Path to the borg executable on the remote. It will default to `borg`.
 - `borg_encryption_passcommand`: The standard output of this command is used to unlock the encryption key.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ borgmatic_after_backup_command: []
 borg_one_file_system: true
 borg_exclude_from: []
 borg_encryption_passcommand: false
+borg_lock_wait_time: 5
 borg_ssh_command: false
 borg_remote_path: false
 borg_retention_policy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,7 +77,7 @@
         minute: "{{ 59 |random }}"
         user: "root"
         cron_file: borgmatic
-        job: "/usr/local/bin/borgmatic --create --prune"
+        job: "/usr/local/bin/borgmatic --create"
     - cron:
         name: "borgmatic-check"
         day: "{{ 28 | random }}"
@@ -85,7 +85,7 @@
         minute: "{{ 59 | random }}"
         user: "root"
         cron_file: borgmatic
-        job: "/usr/local/bin/borgmatic --check"
+        job: "/usr/local/bin/borgmatic --check --prune"
   when: borgmatic_large_repo
 
 - name: Add cron-job for borgmatic (normal-sized repo)

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -70,7 +70,7 @@ storage:
     umask: 0077
 
     # Maximum seconds to wait for acquiring a repository/cache lock.
-    lock_wait: 5
+    lock_wait: {{ borg_lock_wait_time }}
 
     # Name of the archive. Borg placeholders can be used. See the output of
     # "borg help placeholders" for details. Default is


### PR DESCRIPTION
I ran into an issue where the default action of create, prune, check was causing high server load on the borg repo machine. It was recommended I use the `borgmatic_large_repo` argument to break out the prune and check actions to run less often. However the `borgmatic_large_repo` bundled prune along with create, so I've updated the check cronjob to also run prune.

This may not be the desired situation for everyone, so if I'm the only one who benefits form this feel free to close this PR.