### PR TITLE
enable EPEL only on RHEL and CentOS

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -4,3 +4,4 @@
     pkg: epel-release
     state: installed
     update_cache: yes
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'


### PR DESCRIPTION
Fedora has `ansible_os_family==RedHat`, but it does not use EPEL.