### PR TITLE
Update package list for Fedora 32

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,10 @@ platforms:
     image: centos:7
   - name: centos-latest
     image: centos:latest
-  # - name: fedora-latest  # epel package not available
-  #   image: fedora:latest
+  - name: fedora-latest
+    image: fedora:latest
+  - name: fedora-31
+    image: fedora:31
   - name: debian-oldstable
     image: debian:oldstable
   - name: debian-stable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,9 @@
 - name: Include OS-specific variables
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
 
 - name: Run OS-specific setup

--- a/vars/Fedora-31.yml
+++ b/vars/Fedora-31.yml
@@ -1,0 +1,21 @@
+---
+borg_packages:
+  - libacl-devel
+  - libacl
+  - gcc
+  - gcc-c++
+  - openssl-devel
+  - python3-pip
+  - python3-wheel
+  - python3-devel
+  - python3-setuptools
+  - openssh-clients
+  - cronie
+
+python_bin: python3
+pip_bin: pip3
+
+borg_python_packages:
+  - cython
+  - borgbackup
+  - borgmatic

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,0 +1,21 @@
+---
+borg_packages:
+  - libacl-devel
+  - libacl
+  - gcc
+  - gcc-c++
+  - openssl-devel
+  - python-pip
+  - python-wheel
+  - python-devel
+  - python-setuptools
+  - openssh-clients
+  - cronie
+
+python_bin: python
+pip_bin: pip
+
+borg_python_packages:
+  - cython
+  - borgbackup
+  - borgmatic


### PR DESCRIPTION
The python packages have been renamed in Fedora 32 (python3-* -> python-*). This PR updates the package list accordingly, while staying compatible with Fedora 31. This resolves #38.

Please review specifically the matching order for variable files in `tasks/main.yml`.