### PR TITLE
Add hooks variable to config template

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ $ git clone https://github.com/borgbase/ansible-role-borgbackup.git roles/borgba
 - `borgmatic_failure_command`: Run this command when an error occurs. E.g. `curl -s -F "token=xxx" -F "user=xxx" -F "message=Error during backup" https://api.pushover.net/1/messages.json`
 - `borgmatic_before_backup_command`: Run this command before the backup. E.g. `dump-a-database /to/file.sql`
 - `borgmatic_after_backup_command`: Run this command after the backup. E.g. `rm /to/file.sql`
+- `borgmatic_hooks`: Hooks to monitor your backups e.g. with [Healthchecks](https://healthchecks.io/). See [official documentation](https://torsion.org/borgmatic/docs/how-to/monitor-your-backups/) for more.
 - `borgmatic_failure_command`: Run this command when an error occurs. E.g. `curl -s -F "token=xxx" -F "user=xxx" -F "message=Error during backup" https://api.pushover.net/1/messages.json`
 - `borg_exclude_patterns`: Paths or patterns to exclude from backup. See [official documentation](https://borgbackup.readthedocs.io/en/stable/usage/help.html#borg-help-patterns) for more.
 - `borg_one_file_system`: Don't cross file-system boundaries. Defaults to `true`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ borgmatic_failure_command:
   - echo "`date` - Error while creating a backup."
 borgmatic_before_backup_command: []
 borgmatic_after_backup_command: []
+borgmatic_hooks: []
 borg_one_file_system: true
 borg_exclude_from: []
 borg_encryption_passcommand: false

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -171,3 +171,7 @@ hooks:
 {% for cmd in borgmatic_failure_command %}
         - {{ cmd }}
 {% endfor %}
+
+{% for hook in borgmatic_hooks %}
+    {{ hook }}: {{ borgmatic_hooks[hook] }}
+{% endfor %}


### PR DESCRIPTION
Borgmatic has the option to add hooks. Example: https://torsion.org/borgmatic/docs/how-to/monitor-your-backups/#healthchecks-hook

The PR adds the option to add additional hooks beside the existing hooks (before_backup or after_backup) to the config template.