### PR TITLE
Support for multiple repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ git clone https://github.com/borgbase/ansible-role-borgbackup.git roles/borgba
 ## Role Variables
 
 ### Required Arguments
-- `borg_repository`: Full path to repository. Your own server or [BorgBase.com](https://www.borgbase.com) repo. Not required when using auto creation of repositories.
+- `borg_repository`: Full path to repository. Your own server or [BorgBase.com](https://www.borgbase.com) repo. Not required when using auto creation of repositories. Can be a list if you want to backup to multiple repositories.
 - `borg_source_directories`: List of local folders to back up.
 
 ### Optional Arguments
@@ -80,7 +80,7 @@ $ git clone https://github.com/borgbase/ansible-role-borgbackup.git roles/borgba
 
 
 ### Optional Arguments for [BorgBase.com](https://www.borgbase.com) repository auto creation
-This role can also set up a new repository on BorgBase, using the arguments below. Thanks to [Philipp Rintz](https://github.com/p-rintz) for contribution this feature.
+This role can also set up a new repository on BorgBase, using the arguments below. Thanks to [Philipp Rintz](https://github.com/p-rintz) for contribution of this feature.
 
 - `create_repo`: Whether to let the role create the repository for the server. Default: False
 - `bb_token`: Your [BorgBase.com](https://www.borgbase.com) API-Token. Should be Create Only for security reasons.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-borg_repository: ''
 borg_encryption_passphrase: ''
 borg_exclude_patterns: []
 borgmatic_config_name: config.yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+borg_repository: ''
 borg_encryption_passphrase: ''
 borg_exclude_patterns: []
 borgmatic_config_name: config.yaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
 
 - name: Set Repository Fact
   set_fact:
-    borg_repository: "{{ repo_creation['data']['repoPath'] }}"
+    borg_repository: "{{ [borg_repository] + [repo_creation['data']['repoPath']] }}"
   when: create_repo
 
 - name: Ensures /etc/borgmatic exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,14 @@
 
 - name: Set Repository Fact
   set_fact:
-    borg_repository: "{{ [borg_repository] + [repo_creation['data']['repoPath']] }}"
+    borg_repository: |-
+          {% if borg_repository is defined and borg_repository is string %}
+          {{ [borg_repository] + [ repo_creation['data']['repoPath'] ] }}
+          {% elif borg_repository is defined %}
+          {{ borg_repository + [ repo_creation['data']['repoPath'] ] }}
+          {% else %}
+          {{ repo_creation['data']['repoPath'] }}
+          {% endif %}
   when: create_repo
 
 - name: Ensures /etc/borgmatic exists

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -11,11 +11,9 @@ location:
     repositories:
 {% if borg_repository is iterable and (borg_repository is not string and borg_repository is not mapping) %}
   {% for repo in borg_repository %}
-    {% if repo != "" %}
         - {{ repo }}
-    {% endif %}
   {% endfor %}
-{% elif borg_repository is defined %}
+{% elif borg_repository is defined and borg_repository is string %}
         - {{ borg_repository }}
 {% endif %}
 

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -1,3 +1,4 @@
+#jinja2: lstrip_blocks: "True", trim_blocks: "True"
 # Full config: https://gist.github.com/coaxial/46e36d89d7b81887f7275d587fe04c44
 location:
     source_directories:
@@ -8,7 +9,15 @@ location:
     # Stay in same file system (do not cross mount points).
     one_file_system: {{ borg_one_file_system }}
     repositories:
+{% if borg_repository is iterable and (borg_repository is not string and borg_repository is not mapping) %}
+  {% for repo in borg_repository %}
+    {% if repo != "" %}
+        - {{ repo }}
+    {% endif %}
+  {% endfor %}
+{% elif borg_repository is defined %}
         - {{ borg_repository }}
+{% endif %}
 
     # Any paths matching these patterns are excluded from backups. Globs and tildes
     # are expanded. See the output of "borg help patterns" for more details.


### PR DESCRIPTION
This PR adds support for multiple repositories in a single call of the role.

By default, this changes nothing. Role configs that simply set the *borg_repository* variable to a repository will continue to work.

If the *borg_repository* variable is set, while also having *create_repo* set, this will combine both to create a repository at borgbase.com, while also including the originally set repository.

If multiple repositories should be set, they will simply need to be given to the role as a list.

ie.:

```
    borg_repository:
      - ssh://borg@backupserver.domain:22/./{{ inventory_hostname }}
      - abcdefg@abcdefg.repo.borgbase.com:repo
```

I was not able to test these changes via the molecule test suite as I am using Fedora 33, and Docker is simply not available there currently, it seems. (podman is the default and the official docker repositories arent available for Fedora 33).

I tested this via my borgbase.com account and my own borg backup server.

As such, I also wasnt able to look into adding to the test cases, sadly. Ill have to see if I can install a different distribution to go back to this if you would like me to.