### PR TITLE
install packages in a single step

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,9 +15,8 @@
 
 - name: Install required System Packages
   package:
-    pkg: "{{ item }}"
+    name: "{{ borg_packages }}"
     state: present
-  with_items: "{{ borg_packages }}"
 
 - name: Update setuptools if needed
   tags: skip_ansible_lint


### PR DESCRIPTION
* Install system packages in one step instead of iterating over them
* Use `name` parameter instead of alias `pkg`