### PR TITLE
Make pip install in the user directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can also use the BorgBase-Ansible module directly if needed:
 Pull requests (PR) are welcome, as long as they add features that are relevant for a meaningful number of users. All PRs are tested for style and functionality. To run tests locally (needs Docker):
 
 ```
-$ pip install -r requirements-dev.txt
+$ pip install --user -r requirements-dev.txt
 $ molecule test
 ```
 

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -19,4 +19,4 @@ widely recommended `'--user' flag`_ when invoking ``pip``.
 
 .. code-block:: bash
 
-    $ pip install 'molecule[docker]'
+    $ pip install --user 'molecule[docker]'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,11 +24,13 @@
     name: setuptools
     state: latest
     executable: "{{ pip_bin }}"
+    extra_args: --user
 
 - name: Install required Python Packages
   pip:
     name: "{{ borg_python_packages }}"
     executable: "{{ pip_bin }}"
+    extra_args: --user
 
 - name: Ensure root has SSH key.
   user:


### PR DESCRIPTION
Use "pip install --user" to install in the user directory instead of
overwritting distribution-provided files.