### PR TITLE
Bugfix/quote excludes

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -27,7 +27,7 @@ location:
     # are expanded. See the output of "borg help patterns" for more details.
     exclude_patterns:
 {% for dir in borg_exclude_patterns %}
-        - {{ dir }}
+        - '{{ dir }}'
 {% endfor %}
 
     # Read exclude patterns from one or more separate named files, one pattern per


### PR DESCRIPTION
* Quote the exclude patterns so that you can use patterns starting wildcards: *.iso etc.
* Install python3-llfuse to fix borg(matic) mount errors (borg mount not available: loading FUSE support failed [ImportError: No module named 'llfuse'])