### PR TITLE
Fix BorgBase repository creation

### DIFF
--- a/library/borgbase.py
+++ b/library/borgbase.py
@@ -181,10 +181,11 @@ def main():
     if repo_id is None:
         # Add new repo using the key
         res = add_repo(key_id)
-
+        repo_exist = False
     else:
         # Edit the repo
         res = edit_repo(repo_id, key_id)
+        repo_exist = True
 
     # Setup information for Ansible
     result = dict(


### PR DESCRIPTION
Currently management of repositories at BorgBase seems to be broken as `repo_exist` is undefined