### PR TITLE
don't specify full path in cron

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,7 @@
         minute: "{{ borgmatic_cron_minute }}"
         user: "root"
         cron_file: "{{ borgmatic_cron_name }}"
-        job: "/usr/local/bin/borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} --create --prune"
+        job: "borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} --create --prune"
     - name: Add cron job for infrequent checks
       cron:
         name: "{{ borgmatic_cron_name }}-check"
@@ -103,7 +103,7 @@
         minute: "{{ borgmatic_cron_checks_minute }}"
         user: "root"
         cron_file: "{{ borgmatic_cron_name }}"
-        job: "/usr/local/bin/borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} --check"
+        job: "borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} --check"
   when: borgmatic_large_repo
 
 - name: Add cron-job for borgmatic (normal-sized repo)
@@ -115,7 +115,7 @@
         minute: "{{ borgmatic_cron_minute }}"
         user: "root"
         cron_file: "{{ borgmatic_cron_name }}"
-        job: "/usr/local/bin/borgmatic"
+        job: "borgmatic"
     - name: Ensure separate check cron job is absent
       cron:
         name: "{{ borgmatic_cron_name }}-check"


### PR DESCRIPTION
On Ubuntu the path to borgmatic is `/usr/bin/borgmatic` rather than `/usr/local/bin/borgmatic`. It looks like this was previously thought of and a path set including various directories borgbackup could be in:

```yaml
- name: Set PATH for borgmatic cron job.
  cron:
    user: "root"
    cron_file: "{{ borgmatic_cron_name }}"
    name: PATH
    env: yes
    value: /usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
```

however, the cron jobs still specified the full path making this additional path redundant and breaking it on Ubuntu. This should re-instate the use of the PATH and fix on Ubuntu (which is tested and working on 20.04). FWIW I haven't tested on any other distro as Ubuntu is all I have but it looks like it should work on others too.