### PR TITLE
install borgmatic in virtualenv

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,18 +19,28 @@
     name: "{{ borg_packages }}"
     state: present
 
-- name: Update setuptools if needed
-  tags: skip_ansible_lint
+- name: Create virtualenv for borg
   pip:
-    name: setuptools
-    state: latest
-    executable: "{{ pip_bin }}"
+    name: pip-tools
+    virtualenv: /opt/borgmatic
+    virtualenv_command: "{{ python_bin }} -m venv"
 
 - name: Install required Python Packages
   pip:
     name: "{{ borg_python_packages }}"
-    executable: "{{ pip_bin }}"
+    virtualenv: /opt/borgmatic
   when: borg_python_packages is defined
+
+- name: Create borgmatic command in /usr/local/bin
+  copy:
+    content: |
+      #!/bin/bash
+      . /opt/borgmatic/bin/activate
+      borgmatic "$@"
+    dest: /usr/local/bin/borgmatic
+    owner: root
+    group: root
+    mode: "0755"
 
 - name: Ensure root has SSH key.
   user:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,6 +8,7 @@ borg_packages:
   - python3-dev
   - python3-pip
   - python3-msgpack
+  - python3-venv
   - openssh-client
   - cron
 

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -9,6 +9,7 @@ borg_packages:
   - python3-wheel
   - python3-devel
   - python3-setuptools
+  - python3-virtualenv
   - openssh-clients
   - cronie
 


### PR DESCRIPTION
Should fix  #60.

Install borgmatic in a virtualenv in /opt/borgmatic and create a wrapper script in /usr/local/bin to use borgmatic from that location. Feel free to suggest improvements.

Also tested this on my laptop since an Ubuntu dist-upgrade broke borgmatic and I didn't really like the current system-wide installation (which also includes a not recommended update of setuptools that has been installed from a package).