### PR TITLE
Fixes for #68 (Install borgmatic in virtuanenv)

### DIFF
--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,19 +1,20 @@
 ---
 borg_packages:
-  - libacl-devel
-  - libacl
-  - gcc
-  - gcc-c++
-  - openssl-devel
-  - python3-pip
-  - python3-wheel
-  - python3-devel
-  - python3-setuptools
-  - python3-Cython
-  - openssh-clients
-  - cronie
   - borgbackup
   - borgmatic
+  - cronie
+  - gcc
+  - gcc-c++
+  - libacl
+  - libacl-devel
+  - openssh-clients
+  - openssl-devel
+  - python3-Cython
+  - python3-devel
+  - python3-pip
+  - python3-setuptools
+  - python3-virtualenv
+  - python3-wheel
 
 python_bin: python3
 pip_bin: pip3

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,21 +1,22 @@
 ---
 borg_packages:
-  - libacl-devel
-  - libacl
+  - cronie
   - gcc
   - gcc-c++
-  - openssl-devel
-  - python36-pip
-  - python36-wheel
-  - python36-devel
-  - python-setuptools
+  - libacl
+  - libacl-devel
   - openssh-clients
-  - cronie
+  - openssl-devel
+  - python-setuptools
+  - python36-devel
+  - python36-pip
+  - python36-virtualenv
+  - python36-wheel
 
 python_bin: python3
 pip_bin: pip3
 
 borg_python_packages:
-  - cython
   - borgbackup
   - borgmatic
+  - cython


### PR DESCRIPTION
- Add python3-virtualenv dependency for Fedora and CentOS7