### PR TITLE
Add if around exclude options to prevent yaml error

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -23,19 +23,23 @@ location:
     # Store ctime into archive.
     ctime: {{ borgmatic_store_ctime }}
 
+{% if borg_exclude_patterns|length %}
     # Any paths matching these patterns are excluded from backups. Globs and tildes
     # are expanded. See the output of "borg help patterns" for more details.
     exclude_patterns:
 {% for dir in borg_exclude_patterns %}
         - '{{ dir }}'
 {% endfor %}
+{% endif %}
 
+{% if borg_exclude_from|length %}
     # Read exclude patterns from one or more separate named files, one pattern per
     # line. See the output of "borg help patterns" for more details.
     exclude_from:
 {% for dir in borg_exclude_from %}
         - {{ dir }}
 {% endfor %}
+{% endif %}
 
     # Exclude directories that contain a CACHEDIR.TAG file. See
     # http://www.brynosaurus.com/cachedir/spec.html for details.


### PR DESCRIPTION
On a new CentOS 7 system without setting the `borg_exclude_patterns` and `borg_exclude_from` variables borgmatic will complain about an invalid configuration file:

```
summary:
/etc/borgmatic/config.yaml: Error parsing configuration file
An error occurred while parsing a configuration file at /etc/borgmatic/config.yaml:
At 'location.exclude_patterns': None is not of type 'array'
At 'location.exclude_from': None is not of type 'array'
```

This was after deploying and issuing `borgmatic -I -e repokey`

This change will omit the respective settings when they are empty and thus preventing a configuration error.