### PR TITLE
Adding Debian fuse support

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -10,6 +10,7 @@ borg_packages:
   - python3-msgpack
   - python3-venv
   - openssh-client
+  - libfuse-dev
   - cron
 
 python_bin: python3
@@ -17,5 +18,5 @@ pip_bin: pip3
 
 borg_python_packages:
   - cython
-  - borgbackup
+  - borgbackup[fuse]
   - borgmatic


### PR DESCRIPTION
Hi, this PR adds Debian fuse mount support: [https://torsion.org/borgmatic/docs/how-to/extract-a-backup/](url)

Omit the --archive flag to mount all archives (lazy-loaded):
```
borgmatic mount --mount-point /mnt
```

Or use the "latest" value for the archive to mount the latest successful archive:
```
borgmatic mount --archive latest --mount-point /mnt
```