### PR TITLE
fix empty exclude (#80)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,15 +7,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        path: ansible_role_borgbackup
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
     - name: Install Molecule
       run: |
+        cd ansible_role_borgbackup
         pip install -U pip setuptools wheel
         pip install -r requirements-dev.txt
     # - name: Debugging with tmate
     #   uses: mxschmitt/action-tmate@v3.5
     - name: Test using Molecule
-      run: molecule test
+      run: |
+        cd ansible_role_borgbackup
+        molecule test

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -23,23 +23,13 @@ location:
     # Store ctime into archive.
     ctime: {{ borgmatic_store_ctime }}
 
-{% if borg_exclude_patterns|length %}
     # Any paths matching these patterns are excluded from backups. Globs and tildes
     # are expanded. See the output of "borg help patterns" for more details.
-    exclude_patterns:
-{% for dir in borg_exclude_patterns %}
-        - '{{ dir }}'
-{% endfor %}
-{% endif %}
+    {{ dict(exclude_patterns=borg_exclude_patterns)|to_nice_yaml|indent(6) }}
 
-{% if borg_exclude_from|length %}
     # Read exclude patterns from one or more separate named files, one pattern per
     # line. See the output of "borg help patterns" for more details.
-    exclude_from:
-{% for dir in borg_exclude_from %}
-        - {{ dir }}
-{% endfor %}
-{% endif %}
+    {{ dict(exclude_from=borg_exclude_from)|to_nice_yaml|indent(6) }}
 
     # Exclude directories that contain a CACHEDIR.TAG file. See
     # http://www.brynosaurus.com/cachedir/spec.html for details.


### PR DESCRIPTION
Fixes #80. If the array is empty, nothing was printed in the code while it should have a [] in that case. Recent borgmatic versions throw an error on that.

The code would become quite ugly another if had to be added to print [] in case the array is empty, this is a more elegant implementation. (Not my own find, thanks to Pieter Avonts for the tip when we discussed this)