### PR TITLE
Fix for borg mount not working

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,6 +3,7 @@ borg_packages:
   - libssl-dev
   - libacl1-dev
   - libacl1
+  - libfuse3-dev
   - build-essential
   - python3-setuptools
   - python3-dev

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,3 +5,4 @@ borg_dependent_python_packages:
 borg_python_packages:
   - borgbackup
   - borgmatic
+  - pyfuse3


### PR DESCRIPTION
These dependencies fix painfull error with mounts:
**borg mount not available: loading FUSE support failed**

I have found out, that after llfuse was abandoned by it's developer we've moved to pyfuse3, which still does not fix the infamous problem with inability to mount borg archives as filesystem.
After some experimenting I have found out, that these two dependencies fix the problem on Ubuntu/Debian.
I am too dumb to understand if this is the right way to fix things, but it works for me everywhere I have tested.
Should this patch be accepted by the developers, it would be nice for someone to apply similar change for other distributions, unfortunately I have no option to test it with other distros.

I have successfully tested it with `molecule test` after disabling image for **almalinux-9** which now requires CPU to support `x86-64-v2` architecture, that I do not have access to.