### PR TITLE
Allow specify borg/borgmon version

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ $ git clone https://github.com/borgbase/ansible-role-borgbackup.git roles/ansibl
 - `borgmatic_store_atime`: Store atime into archive. Defaults to `true`
 - `borgmatic_store_ctime`: Store ctime into archive. Defaults to `true`
 - `ssh_key_file`: Path to a private ssh key file (default is `.ssh/id_ed25519`). It generates a ed25519 key if the file doesn't exist yet.
+- `borg_version`: Force a specific borg version to be installed
+- `borgmatic_version`: Force a specific borgmatic version to be installed
 
 
 ## Contributing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,7 @@ borgmatic_cron_minute: "{{ 59 | random(seed=inventory_hostname) }}"
 borgmatic_cron_checks_day: "{{ range(1, 28) | random(seed=inventory_hostname) }}"
 borgmatic_cron_checks_hour: "{{ range(9, 24) | random(seed=inventory_hostname) }}"
 borgmatic_cron_checks_minute: "{{ 59 | random(seed=inventory_hostname) }}"
+
+
+borg_version: false
+borgmatic_version: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,9 +44,11 @@
 
 - name: Install main Python Packages
   pip:
-    name: "{{ borg_python_packages }}"
+    name: "{{ item.name }}"
+    version: "{{ item.version | default(omit, true) }}"
     virtualenv: /opt/borgmatic
   when: borg_python_packages is defined
+  loop: "{{ borg_python_packages }}"
 
 - name: Create borgmatic command in /usr/local/bin
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
     - "{{ ansible_lsb.id }}.yml"
 
 - name: Run OS-specific tasks
-  include: "{{ item }}"
+  include_tasks: "{{ item }}"
   with_first_found:
     - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_os_family }}.yml"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,5 +3,7 @@ borg_dependent_python_packages:
   - cython
   - pkgconfig
 borg_python_packages:
-  - borgbackup
-  - borgmatic
+  - name: borgbackup
+    version: "{{ borg_version }}"
+  - name: borgmatic
+    version: "{{ borgmatic_version }}"


### PR DESCRIPTION
This little PR is here to add the ability to specify the borg / borgmatic version to install.

This make the role able to upgrade / downgrade borg and borgmatic.
By default this role, will behave like before (Use last borg/borgmatic version on first install and don't upgrade on playbook re-run) 