### PR TITLE
Generate hooks in a single to_nice_yaml invocation

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -184,7 +184,4 @@ consistency:
 # Do not forget to set secure permissions on this file as well as on any script listed (chmod 0700) to
 # prevent potential shell injection or privilege escalation.
 hooks:
-{% for hook in borgmatic_hooks %}
-    {{ hook }}:
-        {{ borgmatic_hooks[hook] | to_nice_yaml(indent=2) | trim | indent(8) }}
-{% endfor %}
+{{ {'hooks': borgmatic_hooks} | to_nice_yaml(indent=4, width=1000) }}


### PR DESCRIPTION
Invoking to_nice_yaml on a scalar value generates a two-line YAML document "value\n...\n" which corrupts the value of a hook such as healthcheck which is just a single string URL. Instead of looping over each of the hooks, define a dictionary with hooks at the top level and have to_nice_yaml transform it in a single invocation. Fixes #117.