### PR TITLE
use backports on debian 11 for package install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,7 @@ borgmatic_timer_hour: "{{ range(0, 5) | random(seed=inventory_hostname) }}"
 borgmatic_timer_minute: "{{ range(0, 59) | random(seed=inventory_hostname) }}"
 borg_install_method: "pip"
 borg_require_epel: "{{ ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora' }}"
+borg_require_backports: "{{ ansible_distribution == 'Debian' and ansible_distribution_major_version == '11' }}"
 
 borgmatic_config_name: config.yaml
 borgmatic_hooks:

--- a/tasks/noauto_install_package.yml
+++ b/tasks/noauto_install_package.yml
@@ -13,9 +13,17 @@
             - "'epel-release' in ansible_facts.packages"
           fail_msg: Need EPEL repo to install via distro package.
 
+    - name: Check if backports repo is enabled, if installation from distro is requested
+      when: borg_require_backports
+      ansible.builtin.apt_repository:
+        repo: "deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main"
+        state: present
+      register: __borg_require_backports
+
     - name: Install borgmatic and borg via distribution package manager
       ansible.builtin.package:
         name: "{{ item }}"
-        state: present
+        state: "{{ __borg_require_backports.changed | ternary('latest', 'present') }}"
+        default_release: "{{ borg_require_backports | ternary(ansible_distribution_release + '-backports', omit) }}"
       loop: "{{ borg_distro_packages }}"
 ...


### PR DESCRIPTION
A draft how #131 could be fixed. Not sure if this is a good approach.

When testing it in molecule adapt borg_install_method to `package`. The instances  `archlinux-latest` and `almalinux-9` fail with `package`, but the fail occurs without the commit as well.