### PR TITLE
set default borg_ssh_command

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ borg_lock_wait_time: 5
 borg_ssh_key_type: "ed25519"
 borg_ssh_key_name: "id_{{ borg_ssh_key_type }}"
 borg_ssh_key_file_path: "{{ backup_user_info.home }}/.ssh/{{ borg_ssh_key_name }}"
-borg_ssh_command: false
+borg_ssh_command: "ssh -i {{ borg_ssh_key_file_path }} -o StrictHostKeyChecking=accept-new"
 borg_remote_path: false
 borg_remote_rate_limit: 0
 borg_retention_policy:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ borg_lock_wait_time: 5
 borg_ssh_key_type: "ed25519"
 borg_ssh_key_name: "id_{{ borg_ssh_key_type }}"
 borg_ssh_key_file_path: "{{ backup_user_info.home }}/.ssh/{{ borg_ssh_key_name }}"
-borg_ssh_command: "ssh -i {{ borg_ssh_key_file_path }} -o StrictHostKeyChecking=accept-new"
+borg_ssh_command: "ssh -i {{ borg_ssh_key_file_path }}"
 borg_remote_path: false
 borg_remote_rate_limit: 0
 borg_retention_policy:


### PR DESCRIPTION
Without a default borg_ssh_command, borg_ssh_key_* seem useless.