### PR TITLE
Fix: change systemd unit path

### DIFF
--- a/tasks/noauto_create_timer_systemd.yml
+++ b/tasks/noauto_create_timer_systemd.yml
@@ -24,8 +24,8 @@
         backup: true
         mode: "{{ item.mode }}"
       with_items:
-        - { src: "borgmatic.timer.j2", dest: "/usr/lib/systemd/system/borgmatic.timer", mode: "0644" }
-        - { src: "borgmatic.service.j2", dest: "/usr/lib/systemd/system/borgmatic.service", mode: "0644" }
+        - { src: "borgmatic.timer.j2", dest: "/lib/systemd/system/borgmatic.timer", mode: "0644" }
+        - { src: "borgmatic.service.j2", dest: "/lib/systemd/system/borgmatic.service", mode: "0644" }
 
     - name: Populate service facts
       ansible.builtin.service_facts:


### PR DESCRIPTION
For compatibility with older distributions such as ubuntu 18 and others.
Now /lib is a link to /usr/lib, but before they were different folders, and the systemd units were located in /lib/systemd/system.