### PR TITLE
Fix malformed config if no passphrase set

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -66,8 +66,10 @@ location:
 # https://borgbackup.readthedocs.io/en/stable/usage/general.html#environment-variables for
 # details.
 storage:
+{% if borg_encryption_passphrase %}
     encryption_passphrase: {{ borg_encryption_passphrase }}
 
+{% endif %}
     # The standard output of this command is used to unlock the encryption key. Only
     # use on repositories that were initialized with passcommand/repokey encryption.
     # Note that if both encryption_passcommand and encryption_passphrase are set,


### PR DESCRIPTION
The problem is that if there's no passphrase set, the role will generate this config:

```yaml
storage:
    encryption_passphrase: 

    [etc.]
```
but Borgmatic errors out on this config with a message about `None` not being a string. I considered doing `{{ borg_encryption_passphrase  or "''" }}` but it seemed cleaner to just omit the value entirely. Upstream's default is `''` FWIW. I tested this patch in production and `borgmatic create` successfully runs with it.