### PR TITLE
Fix Debian install failures due to missing libs

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,6 +8,9 @@ borg_pip_packages:
   - libssl-dev
   - libacl1-dev
   - libacl1
+  - liblz4-dev
+  - libzstd-dev
+  - libxxhash-dev
   - build-essential
   - python3-setuptools
   - python3-dev


### PR DESCRIPTION
I tested this successfully against an Ubuntu jammy server we have in production. Before this patch, installation would fail with a message similar to this one:

```
[snipped]

TASK [borgbase.ansible_role_borgbackup : Install main Python packages] ***********************
failed: [mailu.host.seagl.org] (item={'name': 'borgbackup', 'version': False}) => {"ansible_loop_var": "item", "changed": false, "cmd": ["/opt/borgmatic/bin/pip3", "install", "borgbackup"], "item": {"name": "borgbackup", "version": false}, "msg": "stdout: Collecting borgbackup\n  Using cached borgbackup-1.4.0.tar.gz (3.8 MB)\n  Installing build dependencies: started\n  Installing build dependencies: finished with status 'done'\n  Getting requirements to build wheel: started\n  Getting requirements to build wheel: finished with status 'error'\n\n:stderr:   error: subprocess-exited-with-error\n  \n  × Getting requirements to build wheel did not run successfully.\n  │ exit code: 1\n  ╰─> [19 lines of output]\n      Detected and preferring libcrypto [via pkg-config]\n      Detected and preferring liblz4 [via pkg-config]\n      Detected and preferring libzstd [via pkg-config]\n      Traceback (most recent call last):\n        File \"/opt/borgmatic/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py\", line 353, in <module>\n          main()\n        File \"/opt/borgmatic/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py\", line 335, in main\n          json_out['return_val'] = hook(**hook_input['kwargs'])\n        File \"/opt/borgmatic/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py\", line 118, in get_requires_for_build_wheel\n          return hook(config_settings)\n        File \"/tmp/pip-build-env-90wym7_q/overlay/lib/python3.10/site-packages/setuptools/build_meta.py\", line 327, in get_requires_for_build_wheel\n          return self._get_build_requires(config_settings, requirements=[])\n        File \"/tmp/pip-build-env-90wym7_q/overlay/lib/python3.10/site-packages/setuptools/build_meta.py\", line 297, in _get_build_requires\n          self.run_setup()\n        File \"/tmp/pip-build-env-90wym7_q/overlay/lib/python3.10/site-packages/setuptools/build_meta.py\", line 313, in run_setup\n          exec(code, locals())\n        File \"<string>\", line 152, in <module>\n        File \"<string>\", line 125, in lib_ext_kwargs\n      Exception: Could not find xxhash lib/headers, please set BORG_LIBXXHASH_PREFIX or ensure libxxhash.pc is in PKG_CONFIG_PATH.\n      [end of output]\n  \n  note: This error originates from a subprocess, and is likely not a problem with pip.\nerror: subprocess-exited-with-error\n\n× Getting requirements to build wheel did not run successfully.\n│ exit code: 1\n╰─> See above for output.\n\nnote: This error originates from a subprocess, and is likely not a problem with pip.\n"}
ok: [mailu.host.seagl.org] => (item={'name': 'borgmatic', 'version': '>=1.7.11'})

PLAY RECAP ***********************************************************************************
mailu.host.seagl.org       : ok=43   changed=1    unreachable=0    failed=1    skipped=1    rescued=0    ignored=0   
```