### PR TITLE
Add borgmatic_timer_hour and borgmatic_timer_minute to argument_specs.yml

### DIFF
--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -172,6 +172,14 @@ argument_specs:
         type: str
         required: false
         description: If the variable is set, a timer is installed. A choice must be made between "cron" and "systemd".
+      borgmatic_timer_hour:
+        type: str
+        required: false
+        description: Hour when regular create and prune cron/systemd-timer job will run.
+      borgmatic_timer_minute:
+        type: str
+        required: false
+        description: Minute when regular create and prune cron/systemd-timer job will run.
       borg_ssh_key_type:
         type: str
         required: false


### PR DESCRIPTION
These two arguments were missing from the file. Running Ansible would fail with an error:

```
FAILED! => {"argument_errors": ["borgmatic_timer_hour. Supported parameters include: […]
```