### PR TITLE
Add option to run borgmatic as root by another user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,4 +54,5 @@ borg_user: "root"
 borg_group: "root"
 backup_user_info:
   home: "/home/{{ borg_user }}"
+borgmatic_run_as_root: false
 ...

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -232,3 +232,7 @@ argument_specs:
         type: str
         required: false
         description: Comment added to the SSH public key.
+      borgmatic_run_as_root:
+        type: bool
+        required: false
+        description: If the variable is set, systemd will run borgmatic using sudo.

--- a/templates/borgmatic.service.j2
+++ b/templates/borgmatic.service.j2
@@ -12,7 +12,7 @@ ConditionACPower=true
 [Service]
 Type=oneshot
 User={{ borg_user }}
-ExecStart=borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} {{ borgmatic_timer_flags }}
+ExecStart={{ 'sudo ' if borg_user != 'root'}}borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} {{ borgmatic_timer_flags }}
 
 # Source: https://projects.torsion.org/borgmatic-collective/borgmatic/raw/branch/master/sample/systemd/borgmatic.service
 # Security settings for systemd running as root, optional but recommended to improve security. You

--- a/templates/borgmatic.service.j2
+++ b/templates/borgmatic.service.j2
@@ -12,7 +12,7 @@ ConditionACPower=true
 [Service]
 Type=oneshot
 User={{ borg_user }}
-ExecStart={{ 'sudo ' if borg_user != 'root'}}borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} {{ borgmatic_timer_flags }}
+ExecStart={{ 'sudo ' if borgmatic_run_as_root}}borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} {{ borgmatic_timer_flags }}
 
 # Source: https://projects.torsion.org/borgmatic-collective/borgmatic/raw/branch/master/sample/systemd/borgmatic.service
 # Security settings for systemd running as root, optional but recommended to improve security. You


### PR DESCRIPTION
This code makes use of the sudoers file which is automatically added to the systems unit files.
Now packages are installed as `{{ borg_user }}` but systemd uses sudo to run the backup if it is requested by `{{  borgmatic_run_as_root }}.` 

This could be adapted for  #137 as well. 