### PR TITLE
changed indent to be 8 instead of 4 after hook name

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -178,5 +178,5 @@ consistency:
 hooks:
 {% for hook in borgmatic_hooks %}
     {{ hook }}:
-{{ borgmatic_hooks[hook] | to_nice_yaml(indent=4) | indent(4, first=true) }}
+{{ borgmatic_hooks[hook] | to_nice_yaml(indent=4) | indent(8, first=true) }}
 {% endfor %}


### PR DESCRIPTION
This resolves #165, fixing hook indentation.