### PR TITLE
Extract asserts into their own file

### DIFF
--- a/tasks/00_assert.yml
+++ b/tasks/00_assert.yml
@@ -1,0 +1,9 @@
+---
+- name: Ensure legacy hooks aren't used
+  ansible.builtin.assert:
+    that:
+      - borgmatic_failure_command is undefined
+      - borgmatic_before_backup_command is undefined
+      - borgmatic_after_backup_command is undefined
+    msg: Please use the new borgmatic_hooks variable instead of individual before/after/failure hooks.
+...

--- a/tasks/01_install.yml
+++ b/tasks/01_install.yml
@@ -1,14 +1,6 @@
 ---
 - name: Install borgbackup
   block:
-    - name: Ensure legacy hooks aren't used
-      ansible.builtin.assert:
-        that:
-          - borgmatic_failure_command is undefined
-          - borgmatic_before_backup_command is undefined
-          - borgmatic_after_backup_command is undefined
-        msg: Please use the new borgmatic_hooks variable instead of individual before/after/failure hooks.
-
     - name: Include OS-specific variables
       include_vars: "{{ item }}"
       with_first_found:


### PR DESCRIPTION
These don't really belong in the "install" file.

I tested this against a production server - albeit with a lot of other patches also applied. But I'm confident none of them affect my test results.