### PR TITLE
Add option to set SSH key comment

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -10,6 +10,7 @@
     borg_repository: ssh://m5vz9gp4@m5vz9gp4.repo.borgbase.com/./repo
     borgmatic_timer: systemd
     borg_ssh_key_name: id_backup
+    borg_ssh_key_comment: backup key
     borg_ssh_command: "ssh -i {{ borg_ssh_key_file_path }} -o StrictHostKeyChecking=accept-new"
     borg_user: backupuser
     borg_group: backupuser

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ $ git clone https://github.com/borgbase/ansible-role-borgbackup.git roles/ansibl
 - `borg_ssh_key_name`: Name of the SSH public and pivate key. Default `id_ed25519`
 - `borg_ssh_key_file_path`: SSH-key to be used. Default `~/.ssh/{{ borg_ssh_key_name }}`
 - `borg_ssh_key_type`: The algorithm used to generate the SSH private key. Choose: `rsa`, `dsa`, `rsa1`, `ecdsa`, `ed25519`. Default: `ed25519`
+- `borg_ssh_key_comment`: Comment added to the SSH public key.
 - `borg_ssh_command`: Command to use instead of just "ssh". This can be used to specify SSH options.
 - `borg_version`: Force a specific borg version to be installed
 - `borg_venv_path`: Path to store the venv for `borg(backup)` and `borgmatic`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ borg_encryption_passcommand: false
 borg_lock_wait_time: 5
 borg_ssh_key_type: "ed25519"
 borg_ssh_key_name: "id_{{ borg_ssh_key_type }}"
+borg_ssh_key_comment: ''
 borg_ssh_key_file_path: "{{ backup_user_info.home }}/.ssh/{{ borg_ssh_key_name }}"
 borg_ssh_command: false
 borg_remote_path: false

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -192,3 +192,7 @@ argument_specs:
         type: str
         required: false
         description: Name of the SSH public and private key
+      borg_ssh_key_comment:
+        type: str
+        required: false
+        description: Comment added to the SSH public key.

--- a/tasks/03_create_key.yml
+++ b/tasks/03_create_key.yml
@@ -16,6 +16,7 @@
         type: "{{ borg_ssh_key_type }}"
         owner: "{{ borg_user }}"
         group: "{{ borg_group }}"
+        comment: "{{ borg_ssh_key_comment }}"
 
     - name: Read SSH key
       ansible.builtin.slurp:


### PR DESCRIPTION
SSH key comments help to keep track of the various keys. Defaults to empty and is not written as empty to the key.