### PR TITLE
Add option to add flags to borgmatic in cron/systemd-timer job

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ $ git clone https://github.com/borgbase/ansible-role-borgbackup.git roles/ansibl
 - `borgmatic_config_name`: Name to use for the Borgmatic config file. Defaults to `config.yaml`
 - `borgmatic_timer_hour`: Hour when regular create and prune cron/systemd-timer job will run. Defaults to `{{ 6 | random }}`
 - `borgmatic_timer_minute`: Minute when regular create and prune cron/systemd-timer job will run. Defaults to  `{{ 59 | random }}`
+- `borgmatic_timer_flags`: Flags to pass to borgmatic cron/systemd-timer job, like "--log-file /path/to/file.log --log-file-verbosity 2"
 - `borgmatic_hooks`: Hooks to monitor your backups e.g. with [Healthchecks](https://healthchecks.io/). See [official documentation](https://torsion.org/borgmatic/docs/how-to/monitor-your-backups/) for more.
 - `borgmatic_timer`: If the variable is set, a timer is installed. A choice must be made between `cron` and `systemd`.
 - `borgmatic_relocated_repo_access_is_ok`: Bypass Borg error about a repository that has been moved. Defaults to `false`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ borgmatic_timer_cron_name: "borgmatic"
 borgmatic_timer: cron
 borgmatic_timer_hour: "{{ range(0, 5) | random(seed=inventory_hostname) }}"
 borgmatic_timer_minute: "{{ range(0, 59) | random(seed=inventory_hostname) }}"
+borgmatic_timer_flags: ""
 borg_install_method: "pip"
 borg_require_epel: "{{ ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora' }}"
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -180,6 +180,10 @@ argument_specs:
         type: str
         required: false
         description: Minute when regular create and prune cron/systemd-timer job will run.
+      borgmatic_timer_flags:
+        type: str
+        required: false
+        description: Flags to pass to borgmatic cron/systemd-timer job, like "--log-file /path/to/file.log --log-file-verbosity 2"
       borgmatic_version:
         type: str
         required: false

--- a/tasks/noauto_create_timer_cron.yml
+++ b/tasks/noauto_create_timer_cron.yml
@@ -13,7 +13,7 @@
         minute: "{{ borgmatic_timer_minute }}"
         user: "{{ borg_user }}"
         cron_file: "{{ borgmatic_timer_cron_name }}"
-        job: "borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }}"
+        job: "borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} {{ borgmatic_timer_flags }}"
 
     - name: Ensure separate check cron job is absent
       cron:

--- a/templates/borgmatic.service.j2
+++ b/templates/borgmatic.service.j2
@@ -12,7 +12,7 @@ ConditionACPower=true
 [Service]
 Type=oneshot
 User={{ borg_user }}
-ExecStart=borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }}
+ExecStart=borgmatic -c /etc/borgmatic/{{ borgmatic_config_name }} {{ borgmatic_timer_flags }}
 
 # Source: https://projects.torsion.org/borgmatic-collective/borgmatic/raw/branch/master/sample/systemd/borgmatic.service
 # Security settings for systemd running as root, optional but recommended to improve security. You


### PR DESCRIPTION
Allows adding flags borgmatic cron/systemd-timer command, like "--log-file /path/to/file.log --log-file-verbosity 2".