### PR TITLE
#180 config.yaml.j2 jinja2 trim_blocks string -> boolean

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: "True", trim_blocks: "True"
+#jinja2: lstrip_blocks: True, trim_blocks: True
 ---
 # Managed by Ansible, please don't edit manually
 


### PR DESCRIPTION
As stated in #180, this made it possible to run the role with Ansible `core 2.19.0b2`. 

I have not done any test on older Ansible versions.