### PR TITLE
Add option to control NoNewPrivileges in borgmatic.service

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ $ git clone https://github.com/borgbase/ansible-role-borgbackup.git roles/ansibl
 - `borgmatic_timer_hour`: Hour when regular create and prune cron/systemd-timer job will run. Defaults to `{{ 6 | random }}`
 - `borgmatic_timer_minute`: Minute when regular create and prune cron/systemd-timer job will run. Defaults to  `{{ 59 | random }}`
 - `borgmatic_timer_flags`: Flags to pass to borgmatic cron/systemd-timer job, like "--log-file /path/to/file.log --log-file-verbosity 2"
+- `borgmatic_systemd_nonewprivileges`: NoNewPrivileges Systemd unit setting to allow running commands with "sudo" in config.yaml. Default is to prevent.
 - `borgmatic_hooks`: Hooks to monitor your backups e.g. with [Healthchecks](https://healthchecks.io/). See [official documentation](https://torsion.org/borgmatic/docs/how-to/monitor-your-backups/) for more.
 - `borgmatic_timer`: If the variable is set, a timer is installed. A choice must be made between `cron` and `systemd`.
 - `borgmatic_relocated_repo_access_is_ok`: Bypass Borg error about a repository that has been moved. Defaults to `false`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,7 @@ borgmatic_timer: cron
 borgmatic_timer_hour: "{{ range(0, 5) | random(seed=inventory_hostname) }}"
 borgmatic_timer_minute: "{{ range(0, 59) | random(seed=inventory_hostname) }}"
 borgmatic_timer_flags: ""
+borgmatic_systemd_nonewprivileges: "yes"
 borg_install_method: "pip"
 borg_require_epel: "{{ ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora' }}"
 

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -191,6 +191,10 @@ argument_specs:
         type: str
         required: false
         description: Flags to pass to borgmatic cron/systemd-timer job, like "--log-file /path/to/file.log --log-file-verbosity 2"
+      borgmatic_systemd_nonewprivileges:
+        type: str
+        required: false
+        description: NoNewPrivileges Systemd unit setting to allow running commands with "sudo" in config.yaml. Default is to prevent.
       borgmatic_version:
         type: str
         required: false

--- a/templates/borgmatic.service.j2
+++ b/templates/borgmatic.service.j2
@@ -22,7 +22,7 @@ LockPersonality=true
 # Certain borgmatic features like Healthchecks integration need MemoryDenyWriteExecute to be off.
 # But you can try setting it to "yes" for improved security if you don't use those features.
 MemoryDenyWriteExecute=no
-NoNewPrivileges=yes
+NoNewPrivileges={{ borgmatic_systemd_nonewprivileges }}
 PrivateDevices=yes
 PrivateTmp=yes
 ProtectClock=yes


### PR DESCRIPTION
When this option is set to the default `yes` it will cause database backups like below to error:

```
    postgresql_databases:
            pg_dump_command: sudo -u postgres pg_dump
            pg_restore_command: sudo -u postgres pg_restore
            psql_command: sudo -u postgres psql
```

This optional flag allows admins to disable this security feature if they wish.