### PR TITLE
Allow install only of Borg and Borgmatic

### DIFF
--- a/tasks/03_create_key.yml
+++ b/tasks/03_create_key.yml
@@ -17,13 +17,15 @@
         owner: "{{ borg_user }}"
         group: "{{ borg_group }}"
         comment: "{{ borg_ssh_key_comment }}"
+      when: borg_ssh_key_file_path is defined and borg_ssh_key_file_path | length > 0
 
     - name: Read SSH key
       ansible.builtin.slurp:
         src: "{{ borg_ssh_key_file_path }}.pub"
       register: backup_local_ssh_key
+      when: borg_ssh_key_file_path is defined and borg_ssh_key_file_path | length > 0
 
     - name: Print key
       ansible.builtin.debug:
         msg: "The generated key is: {{ backup_local_ssh_key['content'] | b64decode }}"
-...
+      when: borg_ssh_key_file_path is defined and borg_ssh_key_file_path | length > 0

--- a/tasks/05_configure.yml
+++ b/tasks/05_configure.yml
@@ -16,4 +16,4 @@
         mode: "0600"
         owner: "{{ borg_user }}"
         group: "{{ borg_group }}"
-...
+      when: borgmatic_config_name is defined and borgmatic_config_name | length > 0


### PR DESCRIPTION
This PR aims to solve https://github.com/borgbase/ansible-role-borgbackup/issues/152 by adding `when` checks on relevant places. In order to only install borg & bormatic, the following would be set
```yaml
    borg_repository: "" # Needs to be set to something, even empty
    borgmatic_config_name: "" # Disables borgmatic configuration
    borg_ssh_key_file_path: "" # Disables ssh key creation
    borgmatic_timer: "" # Disables timers
```
I tried to use existing variables, but any other suggestion is welcome.

Use case that this problem solves:

I have an existing borg/borgmatic repository server where I want to upgrade these installations without adding a new repository. It also has existing repository configurations to be able to restore the data inside the repository server, both for verification and for easier access from colleagues. 