### PR TITLE
Fix venv recreation after Python version change

### DIFF
--- a/tasks/noauto_install_pip.yml
+++ b/tasks/noauto_install_pip.yml
@@ -12,6 +12,25 @@
         name: "{{ borg_pip_packages }}"
         state: present
 
+    - name: Get system Python version
+      ansible.builtin.command: "{{ python_bin }} --version"
+      register: borg_system_python_version
+      changed_when: false
+
+    - name: Check Python version in existing borgmatic venv
+      ansible.builtin.command: "{{ borg_venv_path }}/bin/python --version"
+      register: borg_venv_python_version
+      failed_when: false
+      changed_when: false
+
+    - name: Remove borgmatic venv if Python version doesn't match
+      ansible.builtin.file:
+        path: "{{ borg_venv_path }}"
+        state: absent
+      when:
+        - borg_venv_python_version.rc == 0
+        - borg_venv_python_version.stdout != borg_system_python_version.stdout
+
     - name: Create virtualenv for borg  # noqa package-latest
       ansible.builtin.pip:
         name:


### PR DESCRIPTION
## Summary
- Fixes #113 - `ModuleNotFoundError: No module named 'borgmatic'` after OS upgrade
- After an OS upgrade (e.g., Debian 10→11), the Python version changes but the existing venv still references the old Python binary
- This adds checks before venv creation to detect and recreate the venv when Python versions don't match

## Changes
Added three new tasks to `tasks/noauto_install_pip.yml`:
1. Get the system's current Python version
2. Check the Python version in the existing venv (if any)
3. Remove the venv if versions don't match, allowing it to be recreated

## Test plan
- [ ] Deploy role on a system with existing borgmatic venv
- [ ] Simulate Python version mismatch by manually editing venv
- [ ] Verify venv gets recreated with correct Python version

🤖 Generated with [Claude Code](https://claude.com/claude-code)