### PR TITLE
fix: correct systemd timer reference and enable timer by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,7 @@ borgmatic_timer: cron
 borgmatic_timer_hour: "{{ range(0, 5) | random(seed=inventory_hostname) }}"
 borgmatic_timer_minute: "{{ range(0, 59) | random(seed=inventory_hostname) }}"
 borgmatic_timer_flags: ""
+borgmatic_timer_enabled: true
 borgmatic_systemd_nonewprivileges: "yes"
 borg_install_method: "pip"
 borg_require_epel: "{{ ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora' }}"

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -203,6 +203,11 @@ argument_specs:
         type: str
         required: false
         description: Flags to pass to borgmatic cron/systemd-timer job, like "--log-file /path/to/file.log --log-file-verbosity 2"
+      borgmatic_timer_enabled:
+        type: bool
+        required: false
+        default: true
+        description: Whether to enable and start the systemd timer after installation. Set to false to start the timer manually.
       borgmatic_systemd_nonewprivileges:
         type: str
         required: false

--- a/tasks/noauto_create_timer_systemd.yml
+++ b/tasks/noauto_create_timer_systemd.yml
@@ -29,39 +29,30 @@
         - { src: "borgmatic.timer.j2", dest: "/usr/lib/systemd/system/borgmatic.timer", mode: "0644" }
         - { src: "borgmatic.service.j2", dest: "/usr/lib/systemd/system/borgmatic.service", mode: "0644" }
 
-    - name: Populate service facts
-      ansible.builtin.service_facts:
+    - name: Reload systemd daemon
+      ansible.builtin.systemd:
+        daemon_reload: true
 
-      # If the role is running and the repo is not yet initialized, an error will occur.
-      # Therefore the service is stopped by default and must be started manually.
-    - name: Stop fresh installed borgmatic.timer and borgmatic.service
-      when: "'borgmatic.service' not in ansible_facts.services"
+    - name: Enable and start borgmatic timer
+      when: borgmatic_timer_enabled | default(true) | bool
+      ansible.builtin.systemd:
+        name: borgmatic.timer
+        state: started
+        enabled: true
+
+    - name: Disable borgmatic timer
+      when: not (borgmatic_timer_enabled | default(true) | bool)
       block:
-        - name: Set borgmatic services to stopped - newly installed
+        - name: Stop and disable borgmatic.timer
           ansible.builtin.systemd:
-            name: "{{ item }}"
+            name: borgmatic.timer
             state: stopped
             enabled: false
-            masked: false
-            daemon_reload: true
-          when: item in ansible_facts.services
-          with_items:
-            - borgmatic.service
-
-        # bug: Need own section without masked else the timer are skipped
-        - name: Set borgmatic timers to stopped - newly installed
-          ansible.builtin.systemd:
-            name: "{{ item }}"
-            state: stopped
-            enabled: false
-            daemon_reload: true
-          with_items:
-            - "borgmatic.timer"
 
         - name: Show hints
-          when: "'backup_init_repo' not in ansible_run_tags"
           ansible.builtin.debug:
             msg: >-
-              Attention: Since the repo was not initialized automatically,
-              the systemd service (borgmatic.service) and the timer (borgmatic.timer) are not activated.
+              Attention: borgmatic_timer_enabled is set to false.
+              The systemd timer (borgmatic.timer) is not activated.
+              Enable it manually with: systemctl enable --now borgmatic.timer
 ...

--- a/templates/borgmatic.service.j2
+++ b/templates/borgmatic.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=borgmatic backup
-Wants=backup_normal_repo.timer
+Wants=borgmatic.timer
 Wants=network-online.target
 After=network-online.target
 # Prevent borgmatic from running unless the machine is plugged into power. Remove this line if you


### PR DESCRIPTION
## Summary

- Fixes non-existing systemd timer file referenced (#143)
- Fixes systemd timer not being enabled by default (#164)

## Changes

- **borgmatic.service.j2**: Fixed incorrect timer reference (`backup_normal_repo.timer` → `borgmatic.timer`)
- **defaults/main.yml**: Added `borgmatic_timer_enabled` variable (default: `true`)
- **noauto_create_timer_systemd.yml**: Simplified timer management - now enables timer by default when `borgmatic_timer_enabled` is true
- **argument_specs.yml**: Documented the new `borgmatic_timer_enabled` variable

## Breaking Change Note

The default behavior has changed: the systemd timer is now **enabled by default** after installation. Previously, users had to manually run `systemctl enable --now borgmatic.timer`.

Users who need the old behavior (timer created but not enabled) can set:
```yaml
borgmatic_timer_enabled: false
```

## Test plan

- [ ] Verify timer is created and enabled when `borgmatic_timer: systemd` is set
- [ ] Verify timer is created but not enabled when `borgmatic_timer_enabled: false`
- [ ] Verify the service correctly references `borgmatic.timer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)