### PR TITLE
fix: auto-configure ssh_command for non-default SSH keys

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -105,6 +105,9 @@ retry_wait: {{ borgmatic_retry_wait }}
 # ssh_command: ssh -i ~/.ssh/id_ed25519
 {% if borg_ssh_command %}
 ssh_command: {{ borg_ssh_command }}
+{% elif borg_ssh_key_name != 'id_' ~ borg_ssh_key_type %}
+# Auto-configured for non-default SSH key
+ssh_command: ssh -i {{ borg_ssh_key_file_path }}
 {% endif %}
 
 # Umask to be used for borg create.

--- a/templates/config_1.7.yaml.j2
+++ b/templates/config_1.7.yaml.j2
@@ -106,6 +106,9 @@ storage:
     # ssh_command: ssh -i ~/.ssh/id_ed25519
 {% if borg_ssh_command %}
     ssh_command: {{ borg_ssh_command }}
+{% elif borg_ssh_key_name != 'id_' ~ borg_ssh_key_type %}
+    # Auto-configured for non-default SSH key
+    ssh_command: ssh -i {{ borg_ssh_key_file_path }}
 {% endif %}
 
     # Umask to be used for borg create.


### PR DESCRIPTION
When users set a custom borg_ssh_key_name, the role generates the key but borgmatic wasn't configured to use it. This caused confusing behavior where the custom key was created but not used for auth.

This change auto-detects when a non-default key name is used and generates the appropriate ssh_command, while keeping configs clean for users with default keys.

Closes #133