### PR TITLE
Don't force source_directories to exist

### DIFF
--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -3,10 +3,7 @@
 # Managed by Ansible, please don't edit manually
 
 # Full config: https://torsion.org/borgmatic/docs/reference/config.yaml
-{% if borg_source_directories is not defined or borg_source_directories | length == 0 %}
-source_directories:
-    - /etc/hostname # prevent empty backupconfig
-{% else %}
+{% if borg_source_directories is defined and borg_source_directories | length > 0 %}
 source_directories:
     {% for dir in borg_source_directories %}
     - {{ dir }}


### PR DESCRIPTION
Since [borgmatic 1.7.1](https://torsion.org/borgmatic/how-to/backup-your-databases/#no-source-directories), it is allowed to not include the source directories at all. 

This is helpful for db-only setups, as it makes things clearer. This PR removes the fallback `source_directories`, for borgmatic >= 1.8.