### PR TITLE
Fix to_nice_yaml scalar corruption in borgmatic hooks

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -49,6 +49,7 @@
       borgmatic_hooks:
         before_backup:
         - echo "`date` - Starting backup."
+        healthchecks: https://hc-ping.com/12345678-1234-1234-1234-123456789012
         postgresql_databases:
         - name: users
           hostname: database1.example.org

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -11,3 +11,20 @@
   - name: Ensure produced YAML is valid
     command: |
       yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" /etc/borgmatic/config.yaml
+
+  - name: Read borgmatic config
+    ansible.builtin.slurp:
+      src: /etc/borgmatic/config.yaml
+    register: borgmatic_config
+
+  - name: Parse borgmatic config as YAML
+    ansible.builtin.set_fact:
+      borgmatic_config_parsed: "{{ borgmatic_config.content | b64decode | from_yaml }}"
+
+  - name: Verify healthchecks URL is not corrupted by to_nice_yaml scalar bug
+    ansible.builtin.assert:
+      that:
+        - >-
+          '...' not in (borgmatic_config_parsed.healthchecks |
+          default(borgmatic_config_parsed.hooks.healthchecks | default('')))
+      fail_msg: "healthchecks URL corrupted by to_nice_yaml scalar bug (contains '...')"

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -193,13 +193,9 @@ check_last: {{ borgmatic_check_last }}
 # IMPORTANT: All provided commands and scripts are executed with user permissions of borgmatic.
 # Do not forget to set secure permissions on this file as well as on any script listed (chmod 0700) to
 # prevent potential shell injection or privilege escalation.
-{% for hook in borgmatic_hooks %}
-{{ hook }}:
-{{ borgmatic_hooks[hook] | to_nice_yaml(indent=4) | indent(4, first=true) }}
-{% endfor %}
+{{ borgmatic_hooks | to_nice_yaml(indent=4, width=1000) }}
 
 {% if borgmatic_custom_config is defined and borgmatic_custom_config %}
 # Custom configuration
 {{ borgmatic_custom_config | to_nice_yaml(indent=4) }}
 {% endif %}
-

--- a/templates/config_1.7.yaml.j2
+++ b/templates/config_1.7.yaml.j2
@@ -200,7 +200,4 @@ consistency:
 # Do not forget to set secure permissions on this file as well as on any script listed (chmod 0700) to
 # prevent potential shell injection or privilege escalation.
 hooks:
-{% for hook in borgmatic_hooks %}
-    {{ hook }}:
-{{ borgmatic_hooks[hook] | to_nice_yaml(indent=4) | indent(8, first=true) }}
-{% endfor %}
+{{ borgmatic_hooks | to_nice_yaml(indent=4, width=1000) | indent(4) }}


### PR DESCRIPTION
Resurrects #118, rebased onto current master. to_nice_yaml applied to a scalar value (like a healthchecks URL) produces "value\n...\n" - the YAML document end marker corrupts the config. The per-hook loop applies to_nice_yaml to each hook value individually, triggering this bug for any scalar hook such as a healthcheck URL.

This fix applies to_nice_yaml to the entire borgmatic_hooks dict in a single invocation, avoiding the scalar case entirely, and extends the width to 1000 to prevent PyYAML wrapping long strings (like URLs) at 80 chars. Fix applied to both config.yaml.j2 (borgmatic >= 1.8) and config_1.7.yaml.j2 (borgmatic < 1.8).

Note: yamllint does not catch this bug: the indented ... is parsed as part of the scalar string, making it syntactically valid but semantically wrong for borgbackup. A molecule verify assertion is included that checks the rendered config does not contain the ... string at the content level.

Fixes #117